### PR TITLE
Fix test

### DIFF
--- a/samus/tests/server_test.rs
+++ b/samus/tests/server_test.rs
@@ -19,12 +19,12 @@ fn integration_test_server() {
 
   // Start a simple client
   let mut test_stream = TcpStream::connect("127.0.0.1:6666").unwrap();
-  let mut test_buffer = [0; 48];
+  let mut test_buffer = Vec::with_capacity(48);
 
   // Send a GET request to our server
   test_stream.write_all(b"GET test_key\nDELETE test_key\nSET new_key new_value 100\nGET new_key\n").unwrap();
   test_stream.shutdown(std::net::Shutdown::Write).unwrap();
-  test_stream.read(&mut test_buffer).unwrap();
+  test_stream.read_to_end(&mut test_buffer).unwrap();
 
   let buffer_string = std::str::from_utf8(&test_buffer).unwrap();
   assert_eq!(buffer_string, "test_value\ntest_key\nnew_value\nnew_value\n__TERM__");


### PR DESCRIPTION
`std::io::Read::read` may not read all available data, and will return immediately if some data is available (and will not wait for EOF). `Read::read_to_end` will read all data, and will wait for EOF.

Found by https://github.com/craterbot at https://github.com/rust-lang/rust/pull/140985#issuecomment-2888072634